### PR TITLE
Typo fixes and image rescale

### DIFF
--- a/docs/lecture1-background/slides.html
+++ b/docs/lecture1-background/slides.html
@@ -1209,7 +1209,7 @@ f(\mathbf{x}) = \sum_{i=1}^n x_i^3 + 1
 <p><span class="math display">\[
 \frac{df}{d\mathbf{x}} = \begin{bmatrix} \frac{\partial f}{\partial x_1} \\ \frac{\partial f}{\partial x_2} \\ \frac{\partial f}{\partial x_3} \\ \vdots \end{bmatrix}
 \]</span></p>
-<p>The gradient is a vector that <em>tangent</em> to the function <span class="math inline">\(f\)</span> at the input <span class="math inline">\(\mathbf{x}\)</span>. Just as with derivatives, this means that the gradient defines a <em>linear</em> <em>approximation</em> to the function at the point <span class="math inline">\(\mathbf{x}\)</span>.</p>
+<p>The gradient is a vector that is <em>tangent</em> to the function <span class="math inline">\(f\)</span> at the input <span class="math inline">\(\mathbf{x}\)</span>. Just as with derivatives, this means that the gradient defines a <em>linear</em> <em>approximation</em> to the function at the point <span class="math inline">\(\mathbf{x}\)</span>.</p>
 <p><span class="math display">\[
 f(\mathbf{x}+\mathbf{\epsilon}) \approx f(\mathbf{x}) + \frac{df}{d\mathbf{x}} \cdot \mathbf{\epsilon}
 \]</span></p>

--- a/docs/lecture1-background/slides.html
+++ b/docs/lecture1-background/slides.html
@@ -1088,7 +1088,7 @@ f'(x) = 2x + 3
 </tr>
 <tr class="odd">
 <td><span class="math inline">\(x^a\)</span></td>
-<td><span class="math inline">\(ax\)</span></td>
+<td><span class="math inline">\(ax^{a-1}\)</span></td>
 </tr>
 <tr class="even">
 <td><span class="math inline">\(\log(x)\)</span></td>

--- a/docs/lecture2-linear-regression/slides.html
+++ b/docs/lecture2-linear-regression/slides.html
@@ -404,8 +404,8 @@
 <h2>Logistics</h2>
 <ul>
 <li><p>Homework 1 due <strong>next Tuesday 9/5 at 11:59pm</strong></p></li>
-<li><p>Fill out Github username survey!</p></li>
-<li><p>Office hours <strong>tomorrow 4-5:30pm in MacGregor 322</strong></p></li>
+<li><p>Fill out GitHub username survey!</p></li>
+<li><p>Office hours <strong>tomorrow 4-5:30pm in McGregor 322</strong></p></li>
 <li><p><a href="https://harveymuddcollege.instructure.com/courses/615/pages/course-calendar">Course calendar</a> added to website with lecture notes.</p></li>
 <li><p>Lecture notes are <a href="https://github.com/CS152-Neural-Networks-Fall-2023/CS152-Neural-Networks-Fall-2023.github.io">open source</a>!</p></li>
 </ul>
@@ -629,7 +629,7 @@ MSE(\mathbf{w}, \mathbf{X}, \mathbf{y}) = \frac{1}{N}\sum_{i=1}^N (\mathbf{x}_i^
 <div class="cell-output cell-output-display">
 <div class="quarto-figure quarto-figure-center">
 <figure>
-<p><img data-src="slides_files/figure-revealjs/cell-15-output-1.png"></p>
+<p><img data-src="slides_files/figure-revealjs/cell-15-output-1.png" width="782" height="428"></p>
 </figure>
 </div>
 </div>

--- a/docs/lecture2-linear-regression/slides.html
+++ b/docs/lecture2-linear-regression/slides.html
@@ -793,7 +793,7 @@ MSE(\mathbf{w}, \mathbf{X}, \mathbf{y}) = \frac{1}{N}\sum_{i=1}^N (\mathbf{x}_i^
 <div class="cell-output cell-output-display">
 <div class="quarto-figure quarto-figure-center">
 <figure>
-<p><img data-src="slides_files/figure-revealjs/cell-25-output-1.png" width="782" height="427"></p>
+<p><img data-src="slides_files/figure-revealjs/cell-25-output-1.png" width="521" height="325"></p>
 </figure>
 </div>
 </div>
@@ -802,7 +802,7 @@ MSE(\mathbf{w}, \mathbf{X}, \mathbf{y}) = \frac{1}{N}\sum_{i=1}^N (\mathbf{x}_i^
 <div class="cell-output cell-output-display">
 <div class="quarto-figure quarto-figure-center">
 <figure>
-<p><img data-src="slides_files/figure-revealjs/cell-26-output-1.png" width="782" height="428"></p>
+<p><img data-src="slides_files/figure-revealjs/cell-26-output-1.png" width="521" height="325"></p>
 </figure>
 </div>
 </div>

--- a/docs/lecture2-linear-regression/slides.html
+++ b/docs/lecture2-linear-regression/slides.html
@@ -629,7 +629,7 @@ MSE(\mathbf{w}, \mathbf{X}, \mathbf{y}) = \frac{1}{N}\sum_{i=1}^N (\mathbf{x}_i^
 <div class="cell-output cell-output-display">
 <div class="quarto-figure quarto-figure-center">
 <figure>
-<p><img data-src="slides_files/figure-revealjs/cell-15-output-1.png" width="782" height="428"></p>
+<p><img data-src="slides_files/figure-revealjs/cell-15-output-1.png"></p>
 </figure>
 </div>
 </div>


### PR DESCRIPTION
Hi Prof. Gabe! I just noticed a couple of small typos as I was going back on slides trying to fill in some gaps in my knowledge. I'd never forked an open source repo before so I thought I might as well try it! This PR fixes typos and changes the size of graphics on slide 38 in lecture 2. I also noticed that the graphic on slide 28 in lecture 2 is cut off and might be the wrong graphic as it is a duplicate to the one on slide 23 where the context seems to make more sense.

This is what slide 38 will look like if you accept the changes:

![slide38resized](https://github.com/CS152-Neural-Networks-Fall-2023/CS152-Neural-Networks-Fall-2023.github.io/assets/62525482/34c74814-ccf5-4008-8682-eca9c98a6d51)

